### PR TITLE
Build on MacOS II

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,10 +46,11 @@ set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/src/master.css.inc PROPE
 
 add_executable(litebrowser ${SOURCE} ${HEADERS} ${CMAKE_CURRENT_SOURCE_DIR}/src/master.css.inc src/http_loader.h src/http_loader.cpp)
 
+target_link_options(litebrowser PRIVATE ${LB_LIBS_LDFLAGS})
+
 set_target_properties(${PROJECT_NAME} PROPERTIES
         CXX_STANDARD 11
         C_STANDARD 99
         )
 
 target_link_libraries(litebrowser litehtml ${LB_LIBS_LIBRARIES} Poco::Foundation)
-

--- a/README.md
+++ b/README.md
@@ -1,16 +1,35 @@
-litebrowser-linux
-=================
+# litebrowser-linux
 
-The simple browser based on litehtml engine (linux) 
+A simple browser based on the [litehtml](https://github.com/litehtml/litehtml) engine for Linux and Mac. See [litebrowser](https://github.com/litehtml/litebrowser) for the Windows version.
 
-### Build instructions for linux:
-install dependencies:
+## Pre-requisites on Linux
+
+Install dependencies:
+
  * [POCO C++ Libraries](https://pocoproject.org/)  
  * vim-core for xxd
 
+## Pre-requisites on Mac
+
+Install dependencies using [Homebrew](https://brew.sh/):
+
+ * [poco](https://formulae.brew.sh/formula/poco)
+ * [gtkmm3](https://formulae.brew.sh/formula/gtkmm3)
+ * [gtk+3](https://formulae.brew.sh/formula/gtk+3)
+
+```
+brew install gtkmm3 gtk+3 poco
+```
+
+## Common Build instructions
+
+Clone this repository and build the `litebrowser` executable:
+
 ```
 git clone --recursive https://github.com/litehtml/litebrowser-linux.git
-cd litebrowser-linux/
-cmake ./
+cd litebrowser-linux
+mkdir build
+cd build
+cmake ..
 make
 ```

--- a/src/globals.h
+++ b/src/globals.h
@@ -7,7 +7,11 @@
 #include <vector>
 #include <iostream>
 #include <stdlib.h>
+#ifdef __APPLE__
+#include <stdlib.h>
+#else
 #include <malloc.h>
+#endif
 #include <memory.h>
 #define _USE_MATH_DEFINES
 #include <math.h>


### PR DESCRIPTION
I simplified @NoeMurr's work and based it on the current `litebrowser` sources. The `litebrowser` executable builds and runs well. I ignored some compiler warnings for the time being.

How to build and run the `litebrowser` executable on MacOS:

    brew install gtkmm3 gtk+3 poco

    git clone --recursive https://github.com/litehtml/litebrowser-linux.git
    cd litebrowser-linux

    mkdir build
    cd build
    cmake ..
    make

    ./litebrowser
